### PR TITLE
Inline documentation updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@
 /Syllabore/.vs/Syllabore/v17
 /Syllabore/.vs/Syllabore/FileContentIndex
 /Syllabore/.vs/ProjectEvaluation
+/Syllabore/Syllabore.Example/bin/Debug/net7.0

--- a/Syllabore/Syllabore.Example/Syllabore.Example.csproj
+++ b/Syllabore/Syllabore.Example/Syllabore.Example.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Syllabore/Syllabore/DefaultSyllableGenerator.cs
+++ b/Syllabore/Syllabore/DefaultSyllableGenerator.cs
@@ -1,17 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using static System.Net.WebRequestMethods;
 
 namespace Syllabore
 {
     /// <summary>
-    /// <para>
     /// The default syllable provider used by a vanilla instance
     /// of <see cref="NameGenerator"/>.
-    /// </para>
     /// </summary>
     public class DefaultSyllableGenerator : SyllableGenerator
     {
+        /// <summary>
+        /// Instantiates a new <see cref="DefaultSyllableGenerator"/>
+        /// containing a subset of consonants and vowels from the English
+        /// language. See further details in the wiki at
+        /// <a href="https://github.com/kesac/Syllabore/wiki/DefaultSyllableGenerator">
+        /// https://github.com/kesac/Syllabore/wiki/DefaultSyllableGenerator</a>.
+        /// </summary>
         public DefaultSyllableGenerator()
         {
             this.WithLeadingConsonants("bdlmprst");
@@ -22,7 +28,6 @@ namespace Syllabore
             this.WithProbability(x => x
                     .OfLeadingConsonants(0.95, 0.25)
                     .OfFinalConsonants(0.50, 0.25));
-            
         }
     }
 }

--- a/Syllabore/Syllabore/DeprecatedDefaultNameTransformer.cs
+++ b/Syllabore/Syllabore/DeprecatedDefaultNameTransformer.cs
@@ -5,8 +5,10 @@ using System.Text;
 namespace Syllabore
 {
     /// <summary>
-    /// This transformer creates variations of names by replacing one syllable
-    /// with another syllable. Syllables are derived from <see cref="DefaultSyllableGenerator"/>.
+    /// <b>Deprecated</b>. This transformer was originally used to 
+    /// create variations of names by replacing one syllable
+    /// with another syllable. Syllables were derived from 
+    /// <see cref="DefaultSyllableGenerator"/>.
     /// </summary>
     [Obsolete("No longer used", false)]
     public class DefaultNameTransformer : NameTransformer

--- a/Syllabore/Syllabore/DeprecatedDefaultNameTransformer.cs
+++ b/Syllabore/Syllabore/DeprecatedDefaultNameTransformer.cs
@@ -17,6 +17,9 @@ namespace Syllabore
 
         private Random Random { get; set; }
 
+        /// <summary>
+        /// Deprecated. No longer used.
+        /// </summary>
         [Obsolete("No longer used", false)]
         public DefaultNameTransformer()
         {

--- a/Syllabore/Syllabore/DeprecatedNameTransformer.cs
+++ b/Syllabore/Syllabore/DeprecatedNameTransformer.cs
@@ -4,6 +4,9 @@ using System.Text;
 
 namespace Syllabore
 {
+    /// <summary>
+    /// Deprecated. Use <see cref="TransformSet"/> instead.
+    /// </summary>
     [Obsolete("Use TransformSet instead", false)]
     public class NameTransformer : TransformSet { }
 }

--- a/Syllabore/Syllabore/GeneratorProbability.cs
+++ b/Syllabore/Syllabore/GeneratorProbability.cs
@@ -10,15 +10,64 @@ namespace Syllabore
     /// </summary>
     public class GeneratorProbability
     {
+        /// <summary>
+        /// The probability that a leading vowel exists in the starting syllable. In other
+        /// words, this is the probability that a name starts with a vowel rather than a consonant.
+        /// </summary>
         public double? ChanceStartingSyllableLeadingVowelExists { get; set; }
+
+        /// <summary>
+        /// The probability that a leading vowel in the starting syllable is a sequence. In other
+        /// words, this is the probability that a name starts with a vowel sequence rather than a consonant.
+        /// </summary>
         public double? ChanceStartingSyllableLeadingVowelIsSequence { get; set; }
+
+        /// <summary>
+        /// The probability that a leading consonant exists in a syllable. A leading
+        /// consonant is a consonant that appears before a vowel in a syllable.
+        /// </summary>
         public double? ChanceLeadingConsonantExists { get; set; }
+
+        /// <summary>
+        /// The probability that a leading consonant in a syllable is a sequence. A leading
+        /// consonant sequence is a consonant sequence that appears before a vowel in a syllable.
+        /// </summary>
         public double? ChanceLeadingConsonantIsSequence { get; set; }
+
+        /// <summary>
+        /// The probability that a vowel exists in a syllable.
+        /// </summary>
         public double? ChanceVowelExists { get; set; }
+
+        /// <summary>
+        /// The probability that a vowel in a syllable is a sequence.
+        /// </summary>
         public double? ChanceVowelIsSequence { get; set; }
+
+        /// <summary>
+        /// The probability that a trailing consonant exists in a syllable. A trailing
+        /// consonant is a consonant that appears after a vowel in a syllable.
+        /// </summary>
         public double? ChanceTrailingConsonantExists { get; set; }
+
+        /// <summary>
+        /// The probability that a trailing consonant in a syllable is a sequence. A trailing
+        /// consonant is a consonant that appears after a vowel in a syllable.
+        /// </summary>
         public double? ChanceTrailingConsonantIsSequence { get; set; }
+
+        /// <summary>
+        /// The probability that a final consonant exists in a syllable. Final consonants
+        /// are the same as trailing consonants excecpt they only appear in the final
+        /// syllable of a name.
+        /// </summary>
         public double? ChanceFinalConsonantExists { get; set; }
+
+        /// <summary>
+        /// The probability that a final consonant in a syllable is a sequence. Final consonants
+        /// are the same as trailing consonants excecpt they only appear in the final
+        /// syllable of a name.
+        /// </summary>
         public double? ChanceFinalConsonantIsSequence { get; set; }
     }
 }

--- a/Syllabore/Syllabore/GeneratorProbability.cs
+++ b/Syllabore/Syllabore/GeneratorProbability.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization;
 namespace Syllabore
 {
     /// <summary>
-    /// Contains probability settings in a <see cref="SyllableGenerator"/>.
+    /// Contains the probability settings of a <see cref="SyllableGenerator"/>.
     /// </summary>
     public class GeneratorProbability
     {
@@ -20,8 +20,5 @@ namespace Syllabore
         public double? ChanceTrailingConsonantIsSequence { get; set; }
         public double? ChanceFinalConsonantExists { get; set; }
         public double? ChanceFinalConsonantIsSequence { get; set; }
-
-        public GeneratorProbability() { }
-
     }
 }

--- a/Syllabore/Syllabore/Grapheme.cs
+++ b/Syllabore/Syllabore/Grapheme.cs
@@ -6,18 +6,27 @@ namespace Syllabore
 {
     /// <summary>
     /// <para>
-    /// A <see cref="Grapheme"/> is the most basic indivisible unit
-    /// of a writing system. In Syllabore, they 
-    /// can represent a single vowel, consonant, or sequence.
-    /// </para>
-    /// <para>
-    /// <see cref="Grapheme"/>s are used by <see cref="SyllableGenerator"/>s
-    /// to construct syllables.
+    /// A <see cref="Grapheme"/> is an indivisible unit of a 
+    /// writing system. In Syllabore, <see cref="Grapheme">Graphemes</see> 
+    /// are used to represent vowels, consonants, or sequences.
+    /// <see cref="Grapheme">Graphemes</see> are used directly by 
+    /// <see cref="SyllableGenerator">SyllableGenerators</see>
+    /// when constructing syllables.
     /// </para>
     /// </summary>
     public class Grapheme : IWeighted
     {
+        /// <summary>
+        /// The vowel, consonant, or sequence that 
+        /// this <see cref="Grapheme"/> represents.
+        /// </summary>
         public string Value { get; set; }
+
+        /// <summary>
+        /// The weight of occurrence for this
+        /// <see cref="Grapheme"/>. By default the
+        /// value is 1.
+        /// </summary>
         public int Weight { get; set; }
 
         /// <summary>

--- a/Syllabore/Syllabore/INameGenerator.cs
+++ b/Syllabore/Syllabore/INameGenerator.cs
@@ -11,7 +11,8 @@ namespace Syllabore
     public interface INameGenerator : IGenerator<string>
     {
         /// <summary>
-        /// Returns a new name of the specified syllable length.
+        /// Returns a string representing a name of the specified syllable length.
+        /// Note that syllable length is not the same as string length.
         /// </summary>
         string Next(int syllableLength);
 
@@ -22,6 +23,7 @@ namespace Syllabore
 
         /// <summary>
         /// Returns a new <see cref="Name"/> of the specified syllable length.
+        /// Note that syllable length is not the same as string length.
         /// </summary>
         Name NextName(int syllableLength);
     }

--- a/Syllabore/Syllabore/Json/JsonPropertyCast.cs
+++ b/Syllabore/Syllabore/Json/JsonPropertyCast.cs
@@ -6,20 +6,34 @@ using System.Text.Json.Serialization;
 
 namespace Syllabore.Json
 {
+    /// <summary>
+    /// A special kind of <see cref="JsonConverter{Transform}"/> 
+    /// that's only role is to cast the value of a property to a different <see cref="Type"/>.
+    /// </summary>
     public class JsonPropertyCast<T> : JsonConverter<T>
     {
         private Type TargetType;
 
+        /// <summary>
+        /// Instantiates a new <see cref="JsonPropertyCast{T}"/> that will
+        /// cast properties to the specified <see cref="Type"/>.
+        /// </summary>
         public JsonPropertyCast(Type targetType)
         {
             this.TargetType = targetType;
         }
         
+        /// <summary>
+        /// Override. Reads the value of a property and casts it to the specified <see cref="Type"/>.
+        /// </summary>
         public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return (T)JsonSerializer.Deserialize(ref reader, this.TargetType, options);
         }
 
+        /// <summary>
+        /// Override. Writes the value of a property and casts it to the specified <see cref="Type"/>.
+        /// </summary>
         public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
         {
             JsonSerializer.Serialize(writer, value, this.TargetType, options);

--- a/Syllabore/Syllabore/Json/NameGeneratorSerializer.cs
+++ b/Syllabore/Syllabore/Json/NameGeneratorSerializer.cs
@@ -22,10 +22,27 @@ namespace Syllabore.Json
         /// </summary>
         private static readonly char[] AllowedCharacters = { '\r', '\n', '\u0022' };
 
-        public Type ProviderType { get; set; }
+        /// <summary>
+        /// The class <see cref="Type"/> of a <see cref="NameGenerator"/>'s
+        /// <see cref="NameGenerator.Provider"/> property.
+        /// </summary>
+        public Type ProviderType { get; set; }    // TODO: Rename
+
+        /// <summary>
+        /// The class <see cref="Type"/> of a <see cref="NameGenerator"/>'s
+        /// <see cref="NameGenerator.Transformer"/> property.
+        /// </summary>
         public Type TransformerType { get; set; }
+
+        /// <summary>
+        /// The class <see cref="Type"/> of a <see cref="NameGenerator"/>'s
+        /// <see cref="NameGenerator.Filter"/> property.
+        /// </summary>
         public Type FilterType { get; set; }
 
+        /// <summary>
+        /// Creates a new instance of <see cref="NameGeneratorSerializer"/>.
+        /// </summary>
         public NameGeneratorSerializer()
         {
             this.ProviderType = typeof(SyllableGenerator);

--- a/Syllabore/Syllabore/Name.cs
+++ b/Syllabore/Syllabore/Name.cs
@@ -9,12 +9,12 @@ namespace Syllabore
     public class Name
     {
         /// <summary>
-        /// Ordered syllables that make up this name.
+        /// The ordered syllables that make up this name.
         /// </summary>
         public List<string> Syllables { get; set; }
 
         /// <summary>
-        /// An empty name.
+        /// Instantiates an empty name.
         /// </summary>
         public Name()
         {
@@ -22,7 +22,7 @@ namespace Syllabore
         }
 
         /// <summary>
-        /// Instantiates a name with the desired starting syllables.
+        /// Instantiates a new name with the desired starting syllables.
         /// </summary>
         /// <param name="syllable"></param>
         public Name(params string[] syllable)
@@ -31,7 +31,7 @@ namespace Syllabore
         }
 
         /// <summary>
-        /// Instantiates a name that is a copy of the specified name. (This constructor
+        /// Instantiates a new name that is a copy of the specified name. (This constructor
         /// is useful for a <see cref="INameTransformer"/>.)
         /// </summary>
         /// <param name="copy"></param>
@@ -50,15 +50,22 @@ namespace Syllabore
             return result.Substring(0, 1).ToUpper() + result.Substring(1).ToLower();
         }
 
+        /// <summary>
+        /// A <see cref="Name"/> is equal to another
+        /// <see cref="Name"/> if and only if their
+        /// string representations are also equal.
+        /// </summary>
         public override bool Equals(object obj)
         {
-            if(obj is Name){
-                return (((Name)obj).ToString() == this.ToString());
+            if (obj is Name name)
+            {
+                return (name.ToString() == this.ToString());
             }
 
             return false;
         }
 
+        // Needs to exist for the Equals() override.
         public override int GetHashCode()
         {
             return base.GetHashCode();

--- a/Syllabore/Syllabore/Name.cs
+++ b/Syllabore/Syllabore/Name.cs
@@ -65,8 +65,11 @@ namespace Syllabore
             return false;
         }
 
-        // Needs to exist for the Equals() override.
-        public override int GetHashCode()
+        
+        /// <summary>
+        /// Returns a hash code for this <see cref="Name"/>.
+        /// </summary>
+        public override int GetHashCode() // Needs to exist for the Equals() override.
         {
             return base.GetHashCode();
         }

--- a/Syllabore/Syllabore/NameFilter.cs
+++ b/Syllabore/Syllabore/NameFilter.cs
@@ -5,20 +5,54 @@ using System.Text.RegularExpressions;
 
 namespace Syllabore
 {
-
+    /// <summary>
+    /// The type of condition that a 
+    /// <see cref="FilterConstraint"/> uses.
+    /// </summary>
     public enum FilterCondition
     {
+        /// <summary>
+        /// Condition is met if the name contains a specific substring.
+        /// </summary>
         Contains,
+
+        /// <summary>
+        /// Condition is met if the name starts with a specific substring.
+        /// </summary>
         StartsWith,
+
+        /// <summary>
+        /// Condition is met if the name ends with a specific substring.
+        /// </summary>
         EndsWith,
+
+        /// <summary>
+        /// Condition is met if the name matches a specific regular expression.
+        /// </summary>
         MatchesPattern
     }
 
+    /// <summary>
+    /// A constraint used by a <see cref="NameFilter"/> when
+    /// testing names for validity.
+    /// </summary>
     public class FilterConstraint
     {
+        /// <summary>
+        /// The type of condition names will be tested against.
+        /// (eg. Contains, StartsWith, EndsWith, MatchesPattern)
+        /// </summary>
         public FilterCondition Type { get; set; }
+
+        /// <summary>
+        /// The value that names will be tested against (in conjunction
+        /// with <see cref="Type"/>).
+        /// </summary>
         public string Value { get; set; }
 
+        /// <summary>
+        /// Creates a new <see cref="FilterConstraint"/> with the specified condition and value.
+        /// </summary>
         public FilterConstraint(FilterCondition type, string value)
         {
             this.Type = type;
@@ -33,8 +67,14 @@ namespace Syllabore
     [Serializable]
     public class NameFilter : INameFilter
     {
+        /// <summary>
+        /// The list of constraints that names must pass to be considered valid.
+        /// </summary>
         public List<FilterConstraint> Constraints { get; set; }
 
+        /// <summary>
+        /// Instantiates a new <see cref="NameFilter"/> with no constraints.
+        /// </summary>
         public NameFilter()
         {
             this.Constraints = new List<FilterConstraint>();
@@ -83,7 +123,6 @@ namespace Syllabore
             foreach (string s in prefixes)
             {
                 this.Constraints.Add(new FilterConstraint(FilterCondition.StartsWith, s));
-                // this.Conditions.Add("^" + s.Trim());
             }
 
             return this;

--- a/Syllabore/Syllabore/NameFormatter.cs
+++ b/Syllabore/Syllabore/NameFormatter.cs
@@ -23,6 +23,11 @@ namespace Syllabore
         /// </para>
         /// </summary>
         public string Format { get; set; }
+
+        /// <summary>
+        /// The <see cref="INameGenerator">NameGenerators</see>
+        /// used by this <see cref="NameFormatter"/>.
+        /// </summary>
         public Dictionary<string, INameGenerator> BoundNameGenerators { get; set; }
 
         /// <summary>

--- a/Syllabore/Syllabore/NameGenerator.cs
+++ b/Syllabore/Syllabore/NameGenerator.cs
@@ -19,10 +19,21 @@ namespace Syllabore
     /// </summary>
     public class NameGenerator : INameGenerator
     {
-        private const int DefaultMaximumRetries = 1000;
-        // private const double DefaultTransformChance = 1.0;
 
-        private Random Random { get; set; }
+        /// <summary>
+        /// <para>
+        /// The default maximum number of attempts a <see cref="NameGenerator"/> 
+        /// will make to satisfy its own <see cref="NameFilter"/>. If the maximum
+        /// number of attempts is exceeded, an <see cref="InvalidOperationException"/> will be thrown.
+        /// </para>
+        /// <para>
+        /// Hitting the limit is indicative of a <see cref="NameGenerator"/> that 
+        /// can never satisfy its own <see cref="NameFilter"/>.
+        /// </para>
+        /// </summary>
+        private const int DefaultMaximumRetries = 1000;
+
+        private Random _random;
 
         /// <summary>
         /// <para>
@@ -37,22 +48,22 @@ namespace Syllabore
         public ISyllableGenerator Provider { get; set; }
 
         /// <summary>
-        /// <para>
         /// The name transformer used during name generation.
         /// A vanilla <see cref="NameGenerator"/> will not use a 
         /// transformer by default.
-        /// </para>
         /// </summary>
         public INameTransformer Transformer { get; set; }
 
+        /// <summary>
+        /// The probability that a name will be transformed 
+        /// during the generation process.
+        /// </summary>
         public double TransformerChance { get; set; }
 
         /// <summary>
-        /// <para>
         /// The filter used to validate a <see cref="NameGenerator"/>'s output.
         /// A vanilla <see cref="NameGenerator"/> will not use a 
         /// filter by default.
-        /// </para>
         /// </summary>
         public INameFilter Filter { get; set; }
 
@@ -126,7 +137,7 @@ namespace Syllabore
                 this.UsingFilter(filter);
             }
 
-            this.Random = new Random();
+            _random = new Random();
         }
 
         #endregion
@@ -393,7 +404,7 @@ namespace Syllabore
                 throw new InvalidOperationException("The value of property MinimumSyllables must be less than or equal to property MaximumSyllables. Both values must be postive integers.");
             }
 
-            var syllableLength = this.Random.Next(this.MinimumSyllables, this.MaximumSyllables + 1);
+            var syllableLength = _random.Next(this.MinimumSyllables, this.MaximumSyllables + 1);
             return this.Next(syllableLength);
         }
 
@@ -424,7 +435,7 @@ namespace Syllabore
                 throw new InvalidOperationException("The value of property MinimumSyllables must be less than or equal to property MaximumSyllables. Both values must be postive integers.");
             }
 
-            var syllableLength = this.Random.Next(this.MinimumSyllables, this.MaximumSyllables + 1);
+            var syllableLength = _random.Next(this.MinimumSyllables, this.MaximumSyllables + 1);
             return this.NextName(syllableLength);
         }
 
@@ -464,7 +475,7 @@ namespace Syllabore
                     }
                 }
 
-                if (this.Transformer != null && this.Random.NextDouble() < this.TransformerChance)
+                if (this.Transformer != null && _random.NextDouble() < this.TransformerChance)
                 {
                     result = this.Transformer.Apply(result);
                 }

--- a/Syllabore/Syllabore/NameGenerator.cs
+++ b/Syllabore/Syllabore/NameGenerator.cs
@@ -232,23 +232,6 @@ namespace Syllabore
 
         #region Transformations
 
-        /*
-        /// <summary>
-        /// Sets the name transformer of this <see cref="NameGenerator"/> to the specified <see cref="TransformSet"/>.
-        /// A vanilla <see cref="NameGenerator"/> does not use transformers by default.
-        /// <para>
-        /// The name transformer will be applied to every generated name.
-        /// </para>
-        /// <para>
-        /// When multiple calls to this method is made, the last call will take precedence.
-        /// </para>
-        /// </summary>
-        public NameGenerator UsingTransforms(Func<TransformSet, TransformSet> configure)
-        {
-            return this.UsingTransforms(1.0, configure);
-        }
-        */
-
         /// <summary>
         /// Sets the name transformer of this <see cref="NameGenerator"/> to the specified <see cref="INameTransformer"/>.
         /// A vanilla <see cref="NameGenerator"/> does not use transformers by default.
@@ -469,7 +452,6 @@ namespace Syllabore
                 {
                     if (i == 0 && syllableLength > 1)
                     {
-                        //result.Syllables[i] = this.Provider.NextStartingSyllable();
                         result.Syllables.Add(this.Provider.NextStartingSyllable());
                     }
                     else if (i == syllableLength - 1 && syllableLength > 1)
@@ -482,10 +464,6 @@ namespace Syllabore
                     }
                 }
 
-                //if (this.Transformer != null 
-                //    && this.Transformer.TransformChance.HasValue 
-                //    && this.Random.NextDouble() < this.Transformer.TransformChance)
-                //if (this.Transformer != null)
                 if (this.Transformer != null && this.Random.NextDouble() < this.TransformerChance)
                 {
                     result = this.Transformer.Apply(result);

--- a/Syllabore/Syllabore/NameGenerator.cs
+++ b/Syllabore/Syllabore/NameGenerator.cs
@@ -172,7 +172,7 @@ namespace Syllabore
         /// Sets the syllable generator of this <see cref="NameGenerator"/> to the specified <see cref="SyllableGenerator"/>.
         /// </para>
         /// <para>
-        /// When multiple calls to this method or <see cref="UsingCharacters(string, string)"></see> are made, the last call will take precedence.
+        /// When multiple calls to this method or are made, the last call will take precedence.
         /// </para>
         /// </summary>
         public NameGenerator UsingSyllables(Func<SyllableGenerator, SyllableGenerator> configure)
@@ -186,7 +186,7 @@ namespace Syllabore
         /// Sets the syllable generator of this <see cref="NameGenerator"/> to the specified <see cref="ISyllableGenerator"/>.
         /// </para>
         /// <para>
-        /// When multiple calls to this method or <see cref="UsingCharacters(string, string)"></see> are made, the last call will take precedence.
+        /// When multiple calls to this method are made, the last call will take precedence.
         /// </para>
         /// </summary>
         public NameGenerator UsingSyllables(ISyllableGenerator provider)
@@ -388,10 +388,11 @@ namespace Syllabore
 
         /// <summary>
         /// <para>
-        /// Generates and returns a random name. The name will be consistent with this <see cref="NameGenerator"/>'s syllable provider, name transformer (if it is used), and name filter (if it is used).
+        /// Generates and returns a random name. The name will be consistent with this <see cref="NameGenerator"/>'s 
+        /// syllable provider, name transformer (if it is used), and name filter (if it is used).
         /// </para>
         /// <para>
-        /// If you need to access to individual syllables of a name, use <see cref="NextName"/> instead.
+        /// If you need to access to individual syllables of a name, use <see cref="NextName()"/> instead.
         /// </para>
         /// </summary>
         public string Next()
@@ -416,7 +417,7 @@ namespace Syllabore
         /// syllable provider, name transformer (if it is used), and name filter (if it is used).
         /// </para>
         /// <para>
-        /// If you need to access to individual syllables of a name, use <see cref="NextName"/> instead.
+        /// If you need to access to individual syllables of a name, use <see cref="NextName()"/> instead.
         /// </para>
         /// </summary>
         public string Next(int syllableLength)

--- a/Syllabore/Syllabore/SyllableGenerator.cs
+++ b/Syllabore/Syllabore/SyllableGenerator.cs
@@ -13,24 +13,86 @@ namespace Syllabore
     /// </summary>
     public enum Context
     {
+        /// <summary>
+        /// Default generator context.
+        /// </summary>
         None,
+
+        /// <summary>
+        /// The last added <see cref="Grapheme">grapheme(s)</see> are leading consonants.
+        /// </summary>
         LeadingConsonant,
+
+        /// <summary>
+        /// The last added <see cref="Grapheme">grapheme(s)</see> are leading consonant sequences.
+        /// </summary>
         LeadingConsonantSequence,
+
+        /// <summary>
+        /// The last added <see cref="Grapheme">grapheme(s)</see> are vowels.
+        /// </summary>
         Vowel,
+
+        /// <summary>
+        /// The last added <see cref="Grapheme">grapheme(s)</see> are vowel sequences.
+        /// </summary>
         VowelSequence,
+
+        /// <summary>
+        /// The last added <see cref="Grapheme">grapheme(s)</see> are trailing consonants.
+        /// </summary>
         TrailingConsonant,
+
+        /// <summary>
+        /// The last added <see cref="Grapheme">grapheme(s)</see> are trailing consonant sequences.
+        /// </summary>
         TrailingConsonantSequence,
+
+        /// <summary>
+        /// The last added <see cref="Grapheme">grapheme(s)</see> are final consonants.
+        /// </summary>
         LeadingVowelInStartingSyllable,
+
+        /// <summary>
+        /// The last added <see cref="Grapheme">grapheme(s)</see> are final consonant sequences.
+        /// </summary>
         LeadingVowelSequenceInStartingSyllable,
+
+        /// <summary>
+        /// The last added <see cref="Grapheme">grapheme(s)</see> are final consonants.
+        /// </summary>
         FinalConsonant, 
+
+        /// <summary>
+        /// The last added <see cref="Grapheme">grapheme(s)</see> are final consonant sequences.
+        /// </summary>
         FinalConsonantSequence
     }
 
+    /// <summary>
+    /// Descriptors for the position of a syllable within a name.
+    /// </summary>
     public enum SyllablePosition
     {
+        /// <summary>
+        /// An indeterminate position.
+        /// </summary>
         Unknown,
+
+        /// <summary>
+        /// The first syllable of a name.
+        /// </summary>
         Starting,
+
+        /// <summary>
+        /// Any position that is not the 
+        /// first or last syllable of a name.
+        /// </summary>
         Middle,
+
+        /// <summary>
+        /// The last syllable of a name.
+        /// </summary>
         Ending
     }
 
@@ -53,22 +115,78 @@ namespace Syllabore
         private const double DefaultChanceFinalConsonantBecomesSequence = 0.25;    // Only if consonant final sequences are supplied
 
 
-        private Random Random { get; set; }
-        private Context Context { get; set; } // For contextual command .Sequences()
-        private List<Grapheme> LastChanges { get; set; } // For contextual command .Weight()
+        private Random _random { get; set; }
+        private Context _context { get; set; } // For contextual command .Sequences()
+        private List<Grapheme> _lastChanges { get; set; } // For contextual command .Weight()
+
+        /// <summary>
+        /// Leading consonants are consonants that appear before 
+        /// the vowel within a syllable.
+        /// </summary>
         public List<Grapheme> LeadingConsonants { get; set; }
+
+        /// <summary>
+        /// Leading consonants sequences are sequences that appear 
+        /// before the vowel within a syllable. Consonant sequences are made
+        /// up of more than one <see cref="Grapheme"/>, but are treated
+        /// like a single consonant during syllable generation.
+        /// </summary>
         public List<Grapheme> LeadingConsonantSequences { get; set; }
+
+        /// <summary>
+        /// The vowels that can appear within a syllable.
+        /// </summary>
         public List<Grapheme> Vowels { get; set; }
+
+        /// <summary>
+        /// The vowel sequences that can appear within a syllable.
+        /// Sequences are made up of more than one 
+        /// <see cref="Grapheme"/>, but treated as a single vowel.
+        /// </summary>
         public List<Grapheme> VowelSequences { get; set; }
+
+        /// <summary>
+        /// Trailing consonants are consonants that appear after
+        /// the vowel within a syllable.
+        /// </summary>
         public List<Grapheme> TrailingConsonants { get; set; }
+
+        /// <summary>
+        /// Trailing consonant sequences are sequences that appear
+        /// after the vowel within a syllable. Consonant sequences are made
+        /// up of more than one <see cref="Grapheme"/>, but are treated
+        /// like a single consonant during syllable generation.
+        /// </summary>
         public List<Grapheme> TrailingConsonantSequences { get; set; }
+
+        /// <summary>
+        /// Final consonants are identical to trailing consonants, except
+        /// they only appear in the final syllable of a name.
+        /// </summary>
         public List<Grapheme> FinalConsonants { get; set; }
+
+        /// <summary>
+        /// Final consonant sequences are identical to trailing consonant sequences, 
+        /// except they only appear in the final syllable of a name.
+        /// </summary>
         public List<Grapheme> FinalConsonantSequences { get; set; }
+
+        /// <summary>
+        /// The probability settings for this <see cref="SyllableGenerator"/>.
+        /// </summary>
         public GeneratorProbability Probability { get; set; }
+
+        /// <summary>
+        /// When true, <see cref="SyllableGenerator"/> will not throw an exception
+        /// when it generates an empty string. By default, this is false.
+        /// </summary>
         public bool AllowEmptyStringGeneration { get; set; }
 
         #region Convenience Properties
 
+        /// <summary>
+        /// Returns true if the probability of a leading consonant being generated is greater than zero.
+        /// </summary>
         public bool LeadingConsonantsAllowed 
         { 
             get
@@ -77,6 +195,9 @@ namespace Syllabore
             }
         }
 
+        /// <summary>
+        /// Returns true if the probability of a leading consonant sequence being generated is greater than zero.
+        /// </summary>
         public bool LeadingConsonantSequencesAllowed
         {
             get
@@ -85,6 +206,9 @@ namespace Syllabore
             }
         }
 
+        /// <summary>
+        /// Returns true if the probability of a vowel being generated is greater than zero.
+        /// </summary>
         public bool VowelsAllowed
         {
             get
@@ -93,6 +217,9 @@ namespace Syllabore
             }
         }
 
+        /// <summary>
+        /// Returns true if the probability of a vowel sequence being generated is greater than zero.
+        /// </summary>
         public bool VowelSequencesAllowed
         {
             get
@@ -101,6 +228,9 @@ namespace Syllabore
             }
         }
 
+        /// <summary>
+        /// Returns true if the probability of a trailing consonant being generated is greater than zero.
+        /// </summary>
         public bool TrailingConsonantsAllowed
         {
             get
@@ -109,6 +239,9 @@ namespace Syllabore
             }
         }
 
+        /// <summary>
+        /// Returns true if the probability of a trailing consonant sequence being generated is greater than zero.
+        /// </summary>
         public bool TrailingConsonantSequencesAllowed
         {
             get
@@ -117,6 +250,9 @@ namespace Syllabore
             }
         }
 
+        /// <summary>
+        /// Returns true if the probability of a final consonant being generated is greater than zero.
+        /// </summary>
         public bool FinalConsonantsAllowed
         {
             get
@@ -125,6 +261,9 @@ namespace Syllabore
             }
         }
 
+        /// <summary>
+        /// Returns true if the probability of a final consonant sequence being generated is greater than zero.
+        /// </summary>
         public bool FinalConsonantSequencesAllowed
         {
             get
@@ -133,32 +272,40 @@ namespace Syllabore
             }
         }
 
+        /// <summary>
+        /// Returns true if the probability of a leading vowel being generated within the starting syllable is greater than zero.
+        /// </summary>
         public bool LeadingVowelForStartingSyllableAllowed
         {
             get
             {
-                //return Probability.StartingSyllable.ChanceLeadingVowelExists.HasValue && Probability.StartingSyllable.ChanceLeadingVowelExists > 0;
                 return Probability.ChanceStartingSyllableLeadingVowelExists.HasValue && Probability.ChanceStartingSyllableLeadingVowelExists > 0;
             }
         }
 
+        /// <summary>
+        /// Returns true if the probability of a leading vowel sequence being generated within the starting syllable is greater than zero.
+        /// </summary>
         public bool LeadingVowelSequenceForStartingSyllableAllowed
         {
             get
             {
-                // return Probability.StartingSyllable.ChanceLeadingVowelBecomesSequence.HasValue && Probability.StartingSyllable.ChanceLeadingVowelBecomesSequence > 0;
                 return Probability.ChanceStartingSyllableLeadingVowelIsSequence.HasValue && Probability.ChanceStartingSyllableLeadingVowelIsSequence > 0;
             }
         }
 
         #endregion
 
+        /// <summary>
+        /// Instantiates a new <see cref="SyllableGenerator"/> with
+        /// an empty pool of vowels and consonants.
+        /// </summary>
         public SyllableGenerator()
         {
-            this.Random = new Random();
+            _random = new Random();
             this.Probability = new GeneratorProbability();
-            this.Context = Context.None;
-            this.LastChanges = new List<Grapheme>();
+            _context = Context.None;
+            _lastChanges = new List<Grapheme>();
             this.AllowEmptyStringGeneration = false;
 
             this.LeadingConsonants = new List<Grapheme>();
@@ -172,7 +319,10 @@ namespace Syllabore
         }
 
         /// <summary>
-        /// Adds the specified consonants as consonants that can occur before or after a vowel.
+        /// Adds the specified consonants into the pool of leading and trailing
+        /// consonants.  Within a syllable, leading consonants are consonants 
+        /// that appear before a vowel and trailing consonants are consonants 
+        /// that appear after a vowel.
         /// </summary>
         public SyllableGenerator WithConsonants(params string[] consonants)
         {
@@ -185,7 +335,7 @@ namespace Syllabore
 
             this.LeadingConsonants.AddRange(changes);
             this.TrailingConsonants.AddRange(changes);
-            this.LastChanges.ReplaceWith(changes);
+            _lastChanges.ReplaceWith(changes);
 
             if (this.Probability.ChanceLeadingConsonantExists == null)
             {
@@ -197,13 +347,14 @@ namespace Syllabore
                 this.Probability.ChanceTrailingConsonantExists = DefaultChanceTrailingConsonantExists;
             }
 
-            this.Context = Context.None;
+            _context = Context.None;
 
             return this;
         }
 
         /// <summary>
-        /// Adds the specified consonants as consonants that can occur before a vowel.
+        /// Adds the specified consonants to the pool of leading consonants.
+        /// Within a syllable, leading consonants are consonants that appear before a vowel.
         /// </summary>
         public SyllableGenerator WithLeadingConsonants(params string[] consonants)
         {
@@ -216,41 +367,42 @@ namespace Syllabore
             }
 
             this.LeadingConsonants.AddRange(changes);
-            this.LastChanges.ReplaceWith(changes);
+            _lastChanges.ReplaceWith(changes);
 
             if (this.Probability.ChanceLeadingConsonantExists == null)
             {
                 this.Probability.ChanceLeadingConsonantExists = DefaultChanceLeadingConsonantExists;
             }
 
-            this.Context = Context.LeadingConsonant;
+            _context = Context.LeadingConsonant;
 
             return this;
         }
 
 
         /// <summary>
-        /// Adds the specified consonant sequences as sequences that can occur before a vowel.
+        /// Adds the specified consonant sequences into the pool of leading consonant sequences.
         /// </summary>
         public SyllableGenerator WithLeadingConsonantSequences(params string[] consonantSequences)
         {
             var changes = consonantSequences.Select(x => new Grapheme(x)).ToList();
 
             this.LeadingConsonantSequences.AddRange(changes);
-            this.LastChanges.ReplaceWith(changes);
+            _lastChanges.ReplaceWith(changes);
 
             if(this.Probability.ChanceLeadingConsonantIsSequence == null)
             {
                 this.Probability.ChanceLeadingConsonantIsSequence = DefaultChanceLeadingConsonantBecomesSequence;
             }
 
-            this.Context = Context.LeadingConsonantSequence;
+            _context = Context.LeadingConsonantSequence;
 
             return this;
         }
 
         /// <summary>
-        /// Adds the specified vowels as vowels that can be used to form the 'center' of syllables.
+        /// Adds the specified vowels to the pool of possible vowels this
+        /// <see cref="SyllableGenerator"/> can generate.
         /// </summary>
         public SyllableGenerator WithVowels(params string[] vowels)
         {
@@ -262,40 +414,43 @@ namespace Syllabore
             }
 
             this.Vowels.AddRange(changes);
-            this.LastChanges.ReplaceWith(changes);
+            _lastChanges.ReplaceWith(changes);
 
             if (this.Probability.ChanceVowelExists == null)
             {
                 this.Probability.ChanceVowelExists = DefaultChanceVowelExists;
             }
 
-            this.Context = Context.Vowel;
+            _context = Context.Vowel;
 
             return this;
         }
 
         /// <summary>
-        /// Adds the specified vowel sequences as sequences that can be used to form the 'center' of syllables.
+        /// Adds the specified vowel sequences to the pool of possible vowel sequences this
+        /// <see cref="SyllableGenerator"/> can generate.
         /// </summary>
         public SyllableGenerator WithVowelSequences(params string[] vowelSequences)
         {
             var changes = vowelSequences.Select(x => new Grapheme(x)).ToList();
 
             this.VowelSequences.AddRange(changes);
-            this.LastChanges.ReplaceWith(changes);
+            _lastChanges.ReplaceWith(changes);
 
             if(this.Probability.ChanceVowelIsSequence == null)
             {
                 this.Probability.ChanceVowelIsSequence = DefaultChanceVowelBecomesSequence;
             }
 
-            this.Context = Context.VowelSequence;
+            _context = Context.VowelSequence;
 
             return this;
         }
 
         /// <summary>
-        /// Adds the specified consonants as consonants that can appear after a vowel.
+        /// Adds the specified consonants to the pool of trailing consonants.
+        /// Within a syllable, trailing consonants are consonants that appear 
+        /// after a vowel.
         /// </summary>
         public SyllableGenerator WithTrailingConsonants(params string[] consonants)
         {
@@ -307,14 +462,14 @@ namespace Syllabore
             }
 
             this.TrailingConsonants.AddRange(changes);
-            this.LastChanges.ReplaceWith(changes);
+            _lastChanges.ReplaceWith(changes);
 
             if (this.Probability.ChanceTrailingConsonantExists == null)
             {
                 this.Probability.ChanceTrailingConsonantExists = DefaultChanceTrailingConsonantExists;
             }
 
-            this.Context = Context.TrailingConsonant;
+            _context = Context.TrailingConsonant;
 
             return this;
         }
@@ -327,21 +482,21 @@ namespace Syllabore
         {
             var changes = consonantSequences.Select(x => new Grapheme(x)).ToList();
             this.TrailingConsonantSequences.AddRange(changes);
-            this.LastChanges.ReplaceWith(changes);
+            _lastChanges.ReplaceWith(changes);
 
             if(this.Probability.ChanceTrailingConsonantIsSequence == null)
             {
                 this.Probability.ChanceTrailingConsonantIsSequence = DefaultChanceTrailingConsonantBecomesSequence;
             }
 
-            this.Context = Context.TrailingConsonantSequence;
+            _context = Context.TrailingConsonantSequence;
 
             return this;
         }
 
         /// <summary>
-        /// Adds the specified consonants as consonants that only appear 
-        /// as the final consonant in an ending syllable.
+        /// Adds the specified consonants to the pool of consonants that must only appear 
+        /// as the trailing consonant of an ending syllable.
         /// </summary>
         public SyllableGenerator WithFinalConsonants(params string[] consonants)
         {
@@ -353,45 +508,45 @@ namespace Syllabore
             }
 
             this.FinalConsonants.AddRange(changes);
-            this.LastChanges.ReplaceWith(changes);
+            _lastChanges.ReplaceWith(changes);
 
             if (this.Probability.ChanceFinalConsonantExists == null)
             {
                 this.Probability.ChanceFinalConsonantExists = DefaultChanceFinalConsonantExists;
             }
 
-            this.Context = Context.FinalConsonant;
+            _context = Context.FinalConsonant;
 
             return this;
         }
 
         /// <summary>
-        /// Adds the specified final consonant sequences as sequences that can only appear 
-        /// as the final consonant sequence in an ending syllable.
+        /// Adds the specified consonant sequences to the pool of sequences that must only appear 
+        /// as the trailing consonant sequence of an ending syllable.
         /// </summary>
         public SyllableGenerator WithFinalConsonantSequences(params string[] consonantSequences)
         {
             var changes = consonantSequences.Select(x => new Grapheme(x)).ToList();
             this.FinalConsonantSequences.AddRange(changes);
-            this.LastChanges.ReplaceWith(changes);
+            _lastChanges.ReplaceWith(changes);
 
             if (this.Probability.ChanceFinalConsonantIsSequence == null)
             {
                 this.Probability.ChanceFinalConsonantIsSequence = DefaultChanceFinalConsonantBecomesSequence;
             }
 
-            this.Context = Context.FinalConsonantSequence;
+            _context = Context.FinalConsonantSequence;
 
             return this;
         }
 
         /// <summary>
-        /// Defines the specified sequences for leading consonants, trailing consonants,
-        /// or vowels depending on the context.
+        /// <em>Contextual on the last call.</em> Adds the specified sequences as
+        /// leading consonants, trailing consonants, or vowels depending on the context.
         /// </summary>
         public SyllableGenerator Sequences(params string[] sequences)
         {
-            switch (this.Context)
+            switch (_context)
             {
                 case Context.LeadingConsonant:
                     this.WithLeadingConsonantSequences(sequences);
@@ -406,18 +561,21 @@ namespace Syllabore
                     this.WithFinalConsonantSequences(sequences);
                     break;
                 default:
-                    this.Context = Context.None;
+                    _context = Context.None;
                     break;
             }
 
             return this;
         }
 
-        
+        /// <summary>
+        /// <em>Contextual on the last call.</em> Sets the weight of the last 
+        /// added <see cref="Grapheme">graphemes</see>.
+        /// </summary>
         public SyllableGenerator Weight(int weight)
         {
 
-            foreach(var g in this.LastChanges)
+            foreach(var g in _lastChanges)
             {
                 g.Weight = weight;
             }
@@ -425,20 +583,8 @@ namespace Syllabore
             return this;
         }
 
-
-        /*
         /// <summary>
-        /// Used to manage the probability of vowels/consonants turning into sequences, of leading
-        /// consonants starting a syllable, of trailing consonants ending a syllable, etc.
-        /// </summary>
-        public SyllableGenerator WithProbability(Func<SyllableProviderProbability, SyllableProviderProbability> configure)
-        {
-            this.Probability = configure(this.Probability);
-            return this;
-        }/**/
-
-        /// <summary>
-        /// Used to manage the probability of vowels/consonants turning into sequences, of leading
+        /// Sets the probability of vowels/consonants turning into sequences, of leading
         /// consonants starting a syllable, of trailing consonants ending a syllable, etc.
         /// </summary>
         public SyllableGenerator WithProbability(Func<GeneratorProbabilityBuilder, GeneratorProbabilityBuilder> configure)
@@ -561,17 +707,27 @@ namespace Syllabore
             }
         }
 
-
+        /// <summary>
+        /// Returns a random syllable suitable for starting a name.
+        /// </summary>
         public virtual string NextStartingSyllable()
         {
             return GenerateSyllable(SyllablePosition.Starting);
         }
 
+        /// <summary>
+        /// Returns a random syllable suitable for any position.
+        /// </summary>
+        /// <returns></returns>
         public virtual string NextSyllable()
         {
             return GenerateSyllable(SyllablePosition.Middle);
         }
 
+        /// <summary>
+        /// Returns a random suitable suitable for ending a name.
+        /// </summary>
+        /// <returns></returns>
         public virtual string NextEndingSyllable()
         {
             return GenerateSyllable(SyllablePosition.Ending);
@@ -583,10 +739,10 @@ namespace Syllabore
 
             if (position == SyllablePosition.Starting 
                 && this.LeadingVowelForStartingSyllableAllowed 
-                && this.Random.NextDouble() < this.Probability.ChanceStartingSyllableLeadingVowelExists)
+                && _random.NextDouble() < this.Probability.ChanceStartingSyllableLeadingVowelExists)
             {
 
-                if (this.VowelSequencesAllowed && this.Random.NextDouble() < this.Probability.ChanceStartingSyllableLeadingVowelIsSequence)
+                if (this.VowelSequencesAllowed && _random.NextDouble() < this.Probability.ChanceStartingSyllableLeadingVowelIsSequence)
                 {
                     output.Append(this.NextVowelSequence());
                 }
@@ -598,11 +754,11 @@ namespace Syllabore
             else
             {
                 // Determine if there is a leading consonant in this syllable
-                if (this.LeadingConsonantsAllowed && this.Random.NextDouble() < this.Probability.ChanceLeadingConsonantExists)
+                if (this.LeadingConsonantsAllowed && _random.NextDouble() < this.Probability.ChanceLeadingConsonantExists)
                 {
 
                     // If there is a leading consonant, determine if it is a sequence
-                    if (this.LeadingConsonantSequencesAllowed && this.Random.NextDouble() < this.Probability.ChanceLeadingConsonantIsSequence)
+                    if (this.LeadingConsonantSequencesAllowed && _random.NextDouble() < this.Probability.ChanceLeadingConsonantIsSequence)
                     {
                         output.Append(this.NextLeadingConsonantSequence());
                     }
@@ -613,11 +769,11 @@ namespace Syllabore
                 }
 
                 // Determine if there is a vowel in this syllable (by default, this probability is 100%)
-                if(this.VowelsAllowed && this.Random.NextDouble() < this.Probability.ChanceVowelExists)
+                if(this.VowelsAllowed && _random.NextDouble() < this.Probability.ChanceVowelExists)
                 {
 
                     // Then check if the vowel is a vowel sequence
-                    if (this.VowelSequencesAllowed && this.Random.NextDouble() < this.Probability.ChanceVowelIsSequence)
+                    if (this.VowelSequencesAllowed && _random.NextDouble() < this.Probability.ChanceVowelIsSequence)
                     {
                         output.Append(this.NextVowelSequence());
                     }
@@ -633,11 +789,11 @@ namespace Syllabore
             // (as opposed to a 'trailing' consonant)
             if(position == SyllablePosition.Ending
                 && this.FinalConsonantsAllowed
-                && this.Random.NextDouble() < this.Probability.ChanceFinalConsonantExists)
+                && _random.NextDouble() < this.Probability.ChanceFinalConsonantExists)
             {
                 // We need to append a final consonant,
                 // but we need to determine if the consonant is a sequence first
-                if (this.FinalConsonantSequencesAllowed && this.Random.NextDouble() < this.Probability.ChanceFinalConsonantIsSequence)
+                if (this.FinalConsonantSequencesAllowed && _random.NextDouble() < this.Probability.ChanceFinalConsonantIsSequence)
                 {
                     output.Append(this.NextFinalConsonantSequence());
                 }
@@ -647,11 +803,11 @@ namespace Syllabore
                 }
             }
             // Otherwise, roll for a trailing consonant
-            else if (this.TrailingConsonantsAllowed && this.Random.NextDouble() < this.Probability.ChanceTrailingConsonantExists)
+            else if (this.TrailingConsonantsAllowed && _random.NextDouble() < this.Probability.ChanceTrailingConsonantExists)
             {
                 // If we need to append a trailing consonant, check if
                 // we need a sequence instead
-                if (this.TrailingConsonantSequencesAllowed && this.Random.NextDouble() < this.Probability.ChanceTrailingConsonantIsSequence)
+                if (this.TrailingConsonantSequencesAllowed && _random.NextDouble() < this.Probability.ChanceTrailingConsonantIsSequence)
                 {
                     output.Append(this.NextTrailingConsonantSequence());
                 }

--- a/Syllabore/Syllabore/SyllableSet.cs
+++ b/Syllabore/Syllabore/SyllableSet.cs
@@ -20,14 +20,38 @@ namespace Syllabore
     /// </summary>
     public class SyllableSet : ISyllableGenerator
     {
+        /// <summary>
+        /// The syllable set size for starting syllables.
+        /// </summary>
         public int StartingSyllableMax { get; set; }
+
+        /// <summary>
+        /// The syllable set size for syllables occurring
+        /// between the starting and ending syllable.
+        /// </summary>
         public int MiddleSyllableMax { get; set; }
+
+        /// <summary>
+        /// The syllable set size for ending syllables.
+        /// </summary>
         public int EndingSyllableMax { get; set; }
 
-        private ISyllableGenerator Provider { get; set; }
+        private ISyllableGenerator _generator { get; set; }
 
+        /// <summary>
+        /// The finite set of syllables to be used in the starting position of a name.
+        /// </summary>
         public HashSet<string> StartingSyllables { get; set; }
+
+        /// <summary>
+        /// The finite set of syllables to be used between the starting and ending
+        /// positions of a name.
+        /// </summary>
         public HashSet<string> MiddleSyllables { get; set; }
+
+        /// <summary>
+        /// The finite set of syllables to be used in the ending position of a name.
+        /// </summary>
         public HashSet<string> EndingSyllables { get; set; }
 
         /// <summary>
@@ -75,7 +99,7 @@ namespace Syllabore
         /// </summary>
         public SyllableSet WithGenerator(ISyllableGenerator provider)
         {
-            this.Provider = provider;
+            _generator = provider;
             return this;
         }
 
@@ -150,42 +174,50 @@ namespace Syllabore
             return this;
         }
 
-        // Inherited
+        /// <summary>
+        /// Returns a random syllable suitable for use in the starting position
+        /// of a name.
+        /// </summary>
         public string NextStartingSyllable()
         {
             if (this.StartingSyllables.Count < this.StartingSyllableMax)
             {
                 for (int i = this.StartingSyllables.Count; i < this.StartingSyllableMax; i++)
                 {
-                    this.StartingSyllables.Add(this.Provider.NextStartingSyllable());
+                    this.StartingSyllables.Add(_generator.NextStartingSyllable());
                 }
             }
 
             return this.StartingSyllables.RandomItem<string>();
         }
 
-        // Inherited
+        /// <summary>
+        /// Returns a random syllable suitable for use between the starting and ending
+        /// positions of a name.
+        /// </summary>
         public string NextSyllable()
         {
             if (this.MiddleSyllables.Count < this.MiddleSyllableMax)
             {
                 for (int i = this.MiddleSyllables.Count; i < this.MiddleSyllableMax; i++)
                 {
-                    this.MiddleSyllables.Add(this.Provider.NextSyllable());
+                    this.MiddleSyllables.Add(_generator.NextSyllable());
                 }
             }
 
             return this.MiddleSyllables.RandomItem<string>();
         }
 
-        // Inherited
+        /// <summary>
+        /// Returns a random syllable suitable for use in the ending position of a name.
+        /// </summary>
         public string NextEndingSyllable()
         {
             if (this.EndingSyllables.Count < this.EndingSyllableMax)
             {
                 for (int i = this.EndingSyllables.Count; i < this.EndingSyllableMax; i++)
                 {
-                    this.EndingSyllables.Add(this.Provider.NextEndingSyllable());
+                    this.EndingSyllables.Add(_generator.NextEndingSyllable());
                 }
             }
 

--- a/Syllabore/Syllabore/Transform.cs
+++ b/Syllabore/Syllabore/Transform.cs
@@ -7,24 +7,39 @@ namespace Syllabore
 {
     /// <summary>
     /// <para>
-    /// A <see cref="Transform"/> changes a source name into a new name.
+    /// A <see cref="Transform"/> is a mechanism for changing a source name into 
+    /// a new, modified name. Transforming names is useful for adding some 
+    /// determinism in name generation or for creating iterations on an established name.
     /// </para>
     /// <para>
-    /// <see cref="Transform"/>s can have
-    /// an optional condition that must be fulfilled for a transformation to occur.
+    /// <see cref="Transform">Transforms</see> can have an optional condition that 
+    /// must be fulfilled for a transformation to occur.
     /// </para>
     /// </summary>
     public class Transform : IWeighted, INameTransformer
     {
+        /// <summary>
+        /// The <see cref="TransformStep">steps</see> that this transform will execute.
+        /// </summary>
         public List<TransformStep> Steps { get; set; }
 
         /// <summary>
-        /// A positive integer that influences the probability of this transform being used over others.
-        /// Given two transforms X and Y with a weight of 3 and 1 respectively, transform X will be applied 75% of the time.
-        /// All transforms default to a weight of 1.
+        /// A positive integer that influences the probability of this transform being 
+        /// used over others. Given two transforms X and Y with a weight of 3 and 1 
+        /// respectively, transform X will be applied 75% of the time. All transforms 
+        /// default to a weight of 1.
         /// </summary>
         public int Weight { get; set; }
+
+        /// <summary>
+        /// The index of the syllable that the condition operates on. A negative index 
+        /// can be provided to traverse right-to-left from the end of the name instead.
+        /// </summary>
         public int? ConditionalIndex { get; set; }
+
+        /// <summary>
+        /// A regular expression that must be satisfied for the transform to be applied.
+        /// </summary>
         public string ConditionalRegex { get; set; }
 
         /// <summary>
@@ -109,7 +124,7 @@ namespace Syllabore
 
 
         /// <summary>
-        /// Adds a transform step that replaces a syllable at the specified index with
+        /// Adds a step that replaces a syllable at the specified index with
         /// a desired string.
         /// </summary>
         /// <param name="index">The index can be a negative integer to traverse from the
@@ -124,7 +139,7 @@ namespace Syllabore
         }
 
         /// <summary>
-        /// Adds a transform step that replaces all instances of the specified substring in each syllable with
+        /// Adds a step that replaces all instances of the specified substring in each syllable with
         /// a desired string. Note that the substring must be completely contained in a syllable to be replaced.
         /// </summary>
         public Transform ReplaceAll(string substring, string replacement)
@@ -158,7 +173,7 @@ namespace Syllabore
         }
 
         /// <summary>
-        /// Adds a transform step that removes the syllable at the specified index.
+        /// Adds a step that removes the syllable at the specified index.
         /// </summary>
         /// <param name="index">The index can be a negative integer to traverse from the
         /// end of the name instead. (For example, an index -1 will be interpreted as the

--- a/Syllabore/Syllabore/Transform.cs
+++ b/Syllabore/Syllabore/Transform.cs
@@ -155,7 +155,7 @@ namespace Syllabore
         /// <param name="index">The index can be a negative integer to traverse from the
         /// end of the name instead. (For example, an index -1 will be interpreted as the
         /// last syllable of a name.</param>
-        /// <param name="replacement">The string to insert.</param>
+        /// <param name="syllable">The string to insert.</param>
         /// <returns></returns>
         public Transform InsertSyllable(int index, string syllable)
         {

--- a/Syllabore/Syllabore/TransformSet.cs
+++ b/Syllabore/Syllabore/TransformSet.cs
@@ -9,23 +9,43 @@ namespace Syllabore
 
     /// <summary>
     /// <para>
-    /// A <see cref="TransformSet"/> receives
-    /// a source name, applies one or more <see cref="Transform"/>s, and creates a new name.
-    /// By default, all <see cref="Transform"/>s of the same set are applied to the source name
-    /// and in the order they were added.
+    /// A <see cref="TransformSet"/> takes a source name, 
+    /// applies one or more <see cref="Transform">Transforms</see>, 
+    /// then creates a new name. By default, all 
+    /// <see cref="Transform">Transforms</see> of the same set are 
+    /// applied to the source name and in the order they were added.
     /// </para>
     /// <para>
-    /// To randomize what transforms are applied, make sure to call <see cref="RandomlySelect(int)"/>
-    /// when configuring a <see cref="TransformSet"/>.
+    /// To randomize what transforms are applied, make sure to call 
+    /// <see cref="RandomlySelect(int)"/> when configuring a 
+    /// <see cref="TransformSet"/>.
     /// </para>
     /// </summary>
     [Serializable]
     public class TransformSet : INameTransformer
     {
-        private Random Random;
+        private Random _random;
+
+        /// <summary>
+        /// The <see cref="Transform">Transforms</see> that make up this
+        /// <see cref="TransformSet"/>.
+        /// </summary>
         public List<Transform> Transforms { get; set; }
 
+        /// <summary>
+        /// When true, <see cref="Transform">Transforms</see> are not
+        /// applied in the order they were added. Instead, a random
+        /// number of <see cref="Transform">Transforms</see> are selected
+        /// and applied. Property <see cref="RandomSelectionCount"/> is
+        /// used to determine how many random selections are made.
+        /// </summary>
         public bool UseRandomSelection { get; set; }
+
+        /// <summary>
+        /// When <see cref="UseRandomSelection"/> is true, this property
+        /// is used to determine how many random <see cref="Transform">Transforms</see>
+        /// are selected and applied.
+        /// </summary>
         public int RandomSelectionCount { get; set; }
 
         /// <summary>
@@ -36,7 +56,7 @@ namespace Syllabore
         /// </summary>
         public TransformSet()
         {
-            this.Random = new Random();
+            _random = new Random();
             this.Transforms = new List<Transform>();
             this.UseRandomSelection = false;
             this.RandomSelectionCount = 0;
@@ -108,7 +128,7 @@ namespace Syllabore
                 {
                     int index = transform.ConditionalIndex.Value;
 
-                    if (index < 0) // reverse index provided, so translate into forward index (eg. -1 is the last syllable)
+                    if (index < 0) // reverse index provided, so translate into a forward index (eg. -1 is the last syllable)
                     {
                         index = sourceName.Syllables.Count + index;
                     }
@@ -192,7 +212,6 @@ namespace Syllabore
             this.RandomSelectionCount = limit;
             return this;
         }
-
 
     }
 

--- a/Syllabore/Syllabore/TransformStep.cs
+++ b/Syllabore/Syllabore/TransformStep.cs
@@ -4,13 +4,42 @@ using System.Text;
 
 namespace Syllabore
 {
+    /// <summary>
+    /// The type of action that a <see cref="TransformStep"/> 
+    /// will apply to a <see cref="Name"/>.
+    /// </summary>
     public enum TransformStepType
     {
+        /// <summary>
+        /// Adds a syllable to a <see cref="Name"/>, displacing other
+        /// syllables as needed.
+        /// </summary>
         InsertSyllable,
+
+        /// <summary>
+        /// Adds a syllable to the end of a <see cref="Name"/>.
+        /// </summary>
         AppendSyllable,
+
+        /// <summary>
+        /// Replaces a single syllable with a another syllable.
+        /// </summary>
         ReplaceSyllable,
+
+        /// <summary>
+        /// Deletes a syllable from a <see cref="Name"/>, displacing
+        /// other syllables as needed.
+        /// </summary>
         RemoveSyllable,
-        Lambda, // Note: this one cannot be serialized
+
+        /// <summary>
+        /// An action that is not serializable and expressed in a lambda.
+        /// </summary>
+        Lambda,
+
+        /// <summary>
+        /// Replaces all instances of a substring with another substring.
+        /// </summary>
         ReplaceAllSubstring
     }
 
@@ -19,25 +48,53 @@ namespace Syllabore
     /// </summary>
     public class TransformStep
     {
+        /// <summary>
+        /// The type of action this <see cref="TransformSet"/> represents.
+        /// </summary>
         public TransformStepType Type { get; set; }
-        public List<string> Arguments { get; set; }
-        private Action<Name> UnserializableAction { get; set; }
 
-        public TransformStep()
+        /// <summary>
+        /// The arguments that are passed to the action.
+        /// </summary>
+        public List<string> Arguments { get; set; }
+
+        /// <summary>
+        /// If this <see cref="TransformStep"/> is of type <see cref="TransformStepType.Lambda"/>,
+        /// this property will contain the action to be applied.
+        /// </summary>
+        private Action<Name> _unserializableAction { get; set; }
+
+        /// <summary>
+        /// Instantiates a new <see cref="TransformStep"/> with
+        /// no type or arguments.
+        /// </summary>
+        public TransformStep() // Needs to exist for serialization
         {
             this.Arguments = new List<string>();
         }
 
+        /// <summary>
+        /// Instantiates a new <see cref="TransformStep"/> with
+        /// the specified type and arguments.
+        /// </summary>
         public TransformStep(TransformStepType type, params string[] args)
         {
             this.Type = type;
             this.Arguments = new List<string>(args);
         }
 
+        /// <summary>
+        /// Instantiates a new <see cref="TransformStep"/> with
+        /// type <see cref="TransformStepType.Lambda"/> and the
+        /// specified <see cref="Action"/> to execute.
+        /// Note that this type of <see cref="TransformSet"/> is 
+        /// not serializable.
+        /// </summary>
+        /// <param name="unserializableAction"></param>
         public TransformStep(Action<Name> unserializableAction)
         {
             this.Type = TransformStepType.Lambda;
-            this.UnserializableAction = unserializableAction;
+            _unserializableAction = unserializableAction;
         }
 
         /// <summary>
@@ -104,7 +161,7 @@ namespace Syllabore
             }
             else if(this.Type == TransformStepType.Lambda)
             {
-                UnserializableAction(name);
+                _unserializableAction(name);
             }
             
 


### PR DESCRIPTION
## What is changing?
- Ensured that all classes, methods, and properties have XML documentation
- When using Syllabore in another project, hovering over a Syllabore class, method, or property inside an IDE is guaranteed to display a summary tooltip 

## Why does the change need to happen?
- [ ] It addresses a bug
- [x] It makes the library easier or more appealing to use
- [x] It makes the library easier to maintain
- [ ] It future-proofs the library
